### PR TITLE
Korrektur: Verschiebung der §27 Auszubildende-Einträge von SGB III nach SGB II

### DIFF
--- a/sozialleistungen.yml
+++ b/sozialleistungen.yml
@@ -301,17 +301,16 @@ SGB II:
     themenfelder:
     - Arbeit & Grundsicherung
     - Bildung & Qualifizierung
-SGB III:
-  Leistungen der Ausbildungsförderung:
+  Leistungen für Auszubildende:
   - leistung: Leistungen für Auszubildende, Mehrbedarf für werdende Mütter.
-    rechtsnorm: § 27 Abs. 2 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 2 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
     themenfelder:
     - Bildung & Qualifizierung
   - leistung: Leistungen für Auszubildende, Mehrbedarf für Alleinerziehende.
-    rechtsnorm: § 27 Abs. 2 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 2 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
@@ -319,14 +318,14 @@ SGB III:
     - Bildung & Qualifizierung
   - leistung: Leistungen für Auszubildende, Mehrbedarf für medizinisch bedingte kostenaufwendige
       Ernährung.
-    rechtsnorm: § 27 Abs. 2 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 2 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
     themenfelder:
     - Bildung & Qualifizierung
   - leistung: Leistungen für Auszubildende, Mehrbedarf für besondere Umstände.
-    rechtsnorm: § 27 Abs. 2 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 2 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
@@ -334,38 +333,39 @@ SGB III:
     - Bildung & Qualifizierung
   - leistung: Leistungen für Auszubildende, Erstausstattung bei Schwangerschaft und
       Geburt.
-    rechtsnorm: § 27 Abs. 2 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 2 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
     themenfelder:
     - Bildung & Qualifizierung
   - leistung: Härtefalldarlehen für Auszubildende, Mehrbedarf für dezentrale Warmwassererzeugung.
-    rechtsnorm: § 27 Abs. 3 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 3 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
     themenfelder:
     - Bildung & Qualifizierung
   - leistung: Härtefalldarlehen für Auszubildende, Bedarf für Unterkunft und Heizung.
-    rechtsnorm: § 27 Abs. 3 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 3 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jugendliche
     - Erwerbsalter
     themenfelder:
     - Bildung & Qualifizierung
   - leistung: Härtefalldarlehen für Auszubildende, Bedarf für Bildung und Teilhabe.
-    rechtsnorm: § 27 Abs. 3 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 3 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jedes Alter
     themenfelder:
     - Gesundheit, Pflege & Teilhabe
   - leistung: Härtefalldarlehen für Auszubildende, Beiträge zur Kranken- und Pflegeversicherung.
-    rechtsnorm: § 27 Abs. 3 Versicherungsfreie Beschäftigte SGB III
+    rechtsnorm: § 27 Abs. 3 Leistungen für Auszubildende SGB II
     zielgruppen:
     - Jedes Alter
     themenfelder:
     - Gesundheit, Pflege & Teilhabe
+SGB III:
   Arbeitsförderung:
   - leistung: Aktive Arbeitsförderung, Beratung, Berufsberatung, Weiterbildungsberatung
       für interessierte Arbeitswillige.


### PR DESCRIPTION
## Zusammenfassung

Dieser PR korrigiert einen **Kategorisierungsfehler** im Sozialleistungs-Katalog, bei dem 9 Einträge fälschlicherweise unter **SGB III** statt unter **SGB II** eingeordnet werden.

## Ursache

Im Katalog befinden sich 9 Einträge (Zeile 305 bis Zeile 363) zu Leistungen für Auszubildende, die unter **§27 Abs. 2/3 SGBIII – Versicherungsfreie Beschäftigte** aufgelistet werden. Dies ist falsch.

Tatsächlich werden Leistungen für Auszubildende durch [SGB II §27](https://www.sozialgesetzbuch-sgb.de/sgbii/27.html) geregelt, nicht durch [SGB III §27](https://www.sozialgesetzbuch-sgb.de/sgbiii/27.html).

## Durchgeführte Änderungen

1. 9 Einträge von SGB III nach SGB II verschoben:
- 4 × "Leistungen für Auszubildende, Mehrbedarf" (für Schwangere, Alleinerziehende, medizinisch bedingte kostenaufwendige Ernährung, besondere Umstände)
- 1 × "Leistungen für Auszubildende, Erstausstattung bei Schwangerschaft und Geburt"
- 4 × "Härtefalldarlehen für Auszubildende" (für dezentrale Warmwassererzeugung, Unterkunft und Heizung, Bildung und Teilhabe, Beiträge zur Kranken- und Pflegeversicherung)

2. Neue "Leistungen für Auszubildende" unter SGB II erstellt: 

3. Betroffene Rechtsnormen korrigiert:
- `§27 Abs. 2/3 Versicherungsfreie Beschäftigte SGB III`
- zu `§27 Abs. 2/3 Leistungen für Auszubildende SGB II`

## Rechtliche Validierung

Diese Korrektur basiert auf dem offiziellen Sozialgesetzbuch:

- **[SGB II §27](https://www.sozialgesetzbuch-sgb.de/sgbii/27.html)**: Explizit festgehalten: "Auszubildende im Sinne des §7 Absatz 5 erhalten Leistungen zur Sicherung des Lebensunterhalts" (Auszubildende erhalten Leistungen zur Sicherung des Lebensunterhalts)

- **[SGB III §27](https://www.sozialgesetzbuch-sgb.de/sgbiii/27.html)**: Regelt "Versicherungsfreie Beschäftigte" (von der Arbeitslosenversicherung befreite Beschäftigte) – völlig unabhängig von Leistungen für Auszubildende

- **[Wikipedia: Leistungen für Auszubildende](https://de.wikipedia.org/wiki/Leistungen_f%C3%BCr_Auszubildende)**: Bestätigt, dass Leistungen für Auszubildende unter SGB II §27 fallen


## Checkliste

- [ ] Rechtszitate aktualisiert, um das korrekte Gesetzbuch widerzuspiegeln
- [ ] YAML-Struktur beibehalten
- [ ] Kein Inhalt verloren oder dupliziert
- [ ] Dateigröße unverändert (4095 Zeilen)